### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/freddiefujiwara/fluent-plugin-json-api.png?branch=master)](https://travis-ci.org/freddiefujiwara/fluent-plugin-json-api)
 
-# Fluent::Plugin::Twittersearch
+# Fluent::Plugin::Twittersearch, a plugin for [Fluentd](http://fluentd.org)
 
 TODO: Write a gem description
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
